### PR TITLE
Fall back to arm64e slice when arm64 is missing from .tbd files

### DIFF
--- a/recipe/patches/arm64e-fallback.patch
+++ b/recipe/patches/arm64e-fallback.patch
@@ -1,0 +1,14 @@
+--- a/src/tapi/tools/libtapi/LinkerInterfaceFile.cpp
++++ b/src/tapi/tools/libtapi/LinkerInterfaceFile.cpp
+@@ -179,6 +179,11 @@ static Architecture getArchForCPU(cpu_type_t cpuType, cpu_subtype_t cpuSubType,
+
+   if (enforceCpuSubType)
+     return AK_unknown;
++
++  // macOS 26+ SDK .tbd files only carry arm64e slices.
++  // arm64e is a superset of arm64, so use it as fallback.
++  if (arch == AK_arm64 && archs.has(AK_arm64e))
++    return AK_arm64e;
++
+   return arch;
+ }

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -21,9 +21,12 @@ source:
       # add missing GetDarwinLinkerVersion.cmake; from
       # https://github.com/llvm/llvm-project/commit/3bc71c2abfa00413fd15cf0e5c08af6ec0d4768b
       - patches/cmake-darwin-linker.patch
+      # fall back to arm64e slice when arm64 is missing from .tbd files;
+      # macOS 26+ SDKs only ship arm64e slices (conda-forge/tapi-feedstock#16)
+      - patches/arm64e-fallback.patch
 
 build:
-  number: 0
+  number: 1
   skip: win
   script:
     env:


### PR DESCRIPTION
## Summary

Fixes #16.

macOS 26+ SDKs dropped `arm64-macos` from top-level `.tbd` stub file targets, leaving only `arm64e-macos`. This causes `Undefined symbols for architecture arm64` errors when linking with the conda-forge toolchain.

The patch adds a 3-line fallback in `getArchForCPU()`: when the requested `arm64` slice is missing from a `.tbd` file but `arm64e` is present, return `arm64e`. This should be safe `.tbd` files are just symbol metadata, and the output binary remains `arm64`.

## Test plan

- Reproducer: https://github.com/tdejager/tapi-arm64e-repro
  - `pixi run -e broken test` — confirms the bug (undefined symbols)
  - `pixi run -e fixed test` — builds patched tapi and verifies the fix
- Requires macOS 26.3+ with CommandLineTools SDK (Otherwise it wont fail)
